### PR TITLE
Fixes unrecoverable error when a project has never been built. Fixes bug #19

### DIFF
--- a/JenkinsTransport/Api.cs
+++ b/JenkinsTransport/Api.cs
@@ -173,7 +173,7 @@ namespace JenkinsTransport
                                                   lastCompletedBuildInfo.Timestamp)
                                     {
                                         Activity = EnumUtils.GetProjectActivity(color),
-                                        Status = EnumUtils.GetProjectIntegratorState((bool)firstElement.Element("buildable")),
+                                        Status = EnumUtils.GetProjectIntegratorState(((string)firstElement.Element("buildable"))?.EndsWith("rue") ?? false),
                                         WebURL = (string) firstElement.Element("url"),
                                         LastBuildLabel = lastCompletedBuildInfo.Number,
                                         LastSuccessfulBuildLabel = lastSuccessfulBuildNumber,

--- a/JenkinsTransport/EnumUtils.cs
+++ b/JenkinsTransport/EnumUtils.cs
@@ -62,7 +62,7 @@ namespace JenkinsTransport
         /// <param name="color">the color of the build</param>
         public static IntegrationStatus GetIntegrationStatus(string color)
         {
-            return BuildStatusMap.ContainsKey(color) ? BuildStatusMap[color] : IntegrationStatus.Unknown;
+            return (color != null && BuildStatusMap.ContainsKey(color)) ? BuildStatusMap[color] : IntegrationStatus.Unknown;
         }
 
         /// <summary>
@@ -71,7 +71,7 @@ namespace JenkinsTransport
         /// <param name="color">the color of the build</param>
         public static ProjectActivity GetProjectActivity(string color)
         {
-            return ActivityMap.ContainsKey(color) ? ActivityMap[color] : ProjectActivity.Sleeping;
+            return (color != null && ActivityMap.ContainsKey(color)) ? ActivityMap[color] : ProjectActivity.Sleeping;
         }
 
         /// <summary>


### PR DESCRIPTION
Fixes an unrecoverable application error when a project has no build output and no status. Just some null checks.